### PR TITLE
NextImage コンポーネントの設定を修正

### DIFF
--- a/src/components/NextImage.tsx
+++ b/src/components/NextImage.tsx
@@ -10,7 +10,7 @@ type NextImageProps = {
 export const NextImage: FC<NextImageProps> = ({ src, alt }) => {
   return (
     <div className={styles.container}>
-      <Image src={src} alt={alt} fill sizes="100%" className={styles.image} />
+      <Image src={src} sizes="100vw" alt={alt} fill className={styles.image} />
     </div>
   );
 };

--- a/src/styles/components/NextImage.module.scss
+++ b/src/styles/components/NextImage.module.scss
@@ -1,6 +1,6 @@
 .container {
   position: relative;
-  // width: 100%;
+  width: 100%;
   height: 100%;
 }
 


### PR DESCRIPTION
## やったこと
- `<Image />` コンポーネントの `sizes` prop を `100vw` に変更した

## 気になっていること
### `size` の値をどう指定すればいいかわからない
- デフォルトで `100vw` となっているので、一旦それを指定した
- 参考リンク
  - https://dev.to/yago/understanding-next-image-13ff
  - https://scrapbox.io/mrsekut-p/next%2Fimage%E3%81%AEprops