### PR TITLE
ログイン・ログアウトボタンをコンポーネントに切り出した

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,7 @@
   "plugins": ["react", "@typescript-eslint"],
   "extends": [
     "eslint:recommended",
+    "next/core-web-vitals",
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:react/recommended",

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,8 +6,6 @@ import { useAuth0 } from "@auth0/auth0-react";
 import { useRouter } from "next/router";
 
 export const Header: FC = memo(() => {
-  const { isAuthenticated, loginWithRedirect, logout } = useAuth0();
-
   const { pathname } = useRouter();
 
   return (
@@ -30,55 +28,52 @@ export const Header: FC = memo(() => {
               </li>
             </ul>
           </nav>
-          {isAuthenticated ? (
-            <button
-              className={styles.authButton}
-              onClick={() => logout({ returnTo: window.location.origin })}
-            >
-              <div className={styles.authButtonLeft}>
-                <div className={styles.userIcon}>
-                  <Image
-                    src="/user.svg"
-                    width={14}
-                    height={14}
-                    alt="user-icon"
-                  />
-                </div>
-                <span>ログアウト</span>
-              </div>
-              <Image
-                src="/angle-right.svg"
-                width={6}
-                height={14}
-                alt="angle-right-icon"
-              />
-            </button>
-          ) : (
-            <button
-              className={styles.authButton}
-              onClick={() => loginWithRedirect()}
-            >
-              <div className={styles.authButtonLeft}>
-                <div className={styles.userIcon}>
-                  <Image
-                    src="/user.svg"
-                    width={14}
-                    height={14}
-                    alt="user-icon"
-                  />
-                </div>
-                <span>ログイン</span>
-              </div>
-              <Image
-                src="/angle-right.svg"
-                width={6}
-                height={14}
-                alt="angle-right-icon"
-              />
-            </button>
-          )}
+          <AuthButton />
         </div>
       </div>
     </header>
   );
+});
+
+const AuthButton: FC = memo(() => {
+  const { isAuthenticated, loginWithRedirect, logout } = useAuth0();
+
+  const LogoutButton = (
+    <button
+      className={styles.authButton}
+      onClick={() => logout({ returnTo: window.location.origin })}
+    >
+      <div className={styles.authButtonLeft}>
+        <div className={styles.userIcon}>
+          <Image src="/user.svg" width={14} height={14} alt="user-icon" />
+        </div>
+        <span>ログアウト</span>
+      </div>
+      <Image
+        src="/angle-right.svg"
+        width={6}
+        height={14}
+        alt="angle-right-icon"
+      />
+    </button>
+  );
+
+  const LoginButton = (
+    <button className={styles.authButton} onClick={() => loginWithRedirect()}>
+      <div className={styles.authButtonLeft}>
+        <div className={styles.userIcon}>
+          <Image src="/user.svg" width={14} height={14} alt="user-icon" />
+        </div>
+        <span>ログイン</span>
+      </div>
+      <Image
+        src="/angle-right.svg"
+        width={6}
+        height={14}
+        alt="angle-right-icon"
+      />
+    </button>
+  );
+
+  return isAuthenticated ? LogoutButton : LoginButton;
 });


### PR DESCRIPTION
# やったこと
- ログイン・ログアウトボタンをコンポーネントに切り出した
- eslint の設定を修正
  - `.eslintrc.json` の `extends` に `next/core-web-vitals` を追加